### PR TITLE
Typo maybe? Add missing parenthesis

### DIFF
--- a/src/koans/meditations/08_higher_order_functions.cljs
+++ b/src/koans/meditations/08_higher_order_functions.cljs
@@ -26,7 +26,7 @@
   (= :__ (reduce (fn [a b] (* a b)) [1 2 3 4]))
 
   "You can start somewhere else"
-  (= 2400 (reduce (fn [a b] (* a b)) :__ [1 2 3 4]))
+  (= 2400 (reduce (fn [a b] (* a b)) :__ [1 2 3 4])))
 
   "Numbers are not the only things one can reduce"
   (= "longest" (reduce (fn [a b]


### PR DESCRIPTION
As solution for this line, I came up with the following:

``` clojure
(= 2400 (reduce (fn [a b] (* a b))  (cons 100 [1 2 3 4])) (cond (>= 2 1) 2400  :else  [1 2 3 4]))
```

I was hopping to do something more simpler:

``` clojure
(= 2400 (reduce (fn [a b] (* a b))  (cons 100  [1 2 3 4])))
```

... but it needs one more parenthesis at the end of line (three instead of two).

Maybe I am missing something, I recently started learning Clojure and I found your hosted Koans a good way to play and learn Clojure (Thanks!).
