### PR TITLE
Fix broken links and add official websites.

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,11 +40,12 @@
         <p>You have completed the koans, but your true journey is just beginning. Here are a few resources to help you along your way.</p>
 
         <ul>
+          <li>The official websites for <a href="http://clojure.org/">Clojure</a> and <a href="http://clojurescript.org/">ClojureScript</a></li>
           <li><a href="http://www.amazon.com/gp/product/1935182641/?tag=cljs-koans-20">The Joy of Clojure</a>
           <li>The <a href="http://clojurescript.com">ClojureScript project</a> on GitHub</a></li>
           <li>An in-browser <a href="http://clojurescript.net">ClojureScript REPL</a>
           <li><a href="http://clojuredocs.org">Clojure Docs</a> (core library documentation)</li>
-          <li><a href="http://swannodette.github.io/2013/10/27/the-essence-of-clojurescript/">The Essence of ClojureScript</a> and <a href="http://swannodette.github.io/2013/11/07/clojurescript-101/">ClojureScript 101</a></li>
+          <li><a href="http://swannodette.github.io/2013/10/27/the-essence-of-clojurescript">The Essence of ClojureScript</a> and <a href="http://swannodette.github.io/2013/11/07/clojurescript-101">ClojureScript 101</a></li>
 
         </ul>
 


### PR DESCRIPTION
The trailing slash causes a 404 on swannodette's blog posts.
