### PR TITLE
Fix a typo in a partition meditation

### DIFF
--- a/src/koans/meditations/17_partition.cljs
+++ b/src/koans/meditations/17_partition.cljs
@@ -17,5 +17,5 @@
   "(= '((0 1 2) (3 4 5) (6 :hello)) (partition 3 3 [:__] (range 7)))"
 
   ".. but notice that they will only pad up to given sequence length"
-  "(= '( (0 1 2) (3 4 5) :__) (partition 3 3 [:this :are \"my\" \"words\"] (range 7)))"
+  "(= '( (0 1 2) (3 4 5) :__) (partition 3 3 [:these :are \"my\" \"words\"] (range 7)))"
 ))


### PR DESCRIPTION
This fixes a misused singular pronoun `this` and replaces it with a plural one `these`.

/cc @lazerwalker 