### PR TITLE
Fix broken links and resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,9 @@
           <li><a href="http://www.amazon.com/gp/product/1935182641/?tag=cljs-koans-20">The Joy of Clojure</a>
           <li>The <a href="http://clojurescript.com">ClojureScript project</a> on GitHub</a></li>
           <li>An in-browser <a href="http://clojurescript.net">ClojureScript REPL</a>
-          <li><a href="http://clojuredocs.org">Clojure Docs</a> (core library documentation)</li>
-          <li><a href="http://swannodette.github.io/2013/10/27/the-essence-of-clojurescript/">The Essence of ClojureScript</a> and <a href="http://swannodette.github.io/2013/11/07/clojurescript-101/">ClojureScript 101</a></li>
+          <li><a href="https://clojuredocs.org">Clojure Docs</a> (core library documentation)</li>
+          <li><a href="https://clojurescript.org/guides/quick-start">ClojureScript Quick Start</a></li>
+          <li><a href="https://swannodette.github.io/2013/10/27/the-essence-of-clojurescript">The Essence of ClojureScript</a> and <a href="https://swannodette.github.io/2013/11/07/clojurescript-101">ClojureScript 101</a> (slightly outdated)</li>
 
         </ul>
 


### PR DESCRIPTION
This PR fixes a few broken links in the additional resources list and marks them as slightly outdated.
It also adds the official Quickstart guide referenced by `The Essence of ClojureScript` article.
And, finally, changes the `Clojure Docs` link to use the `https` protocol.

/cc @lazerwalker 