### PR TITLE
Fix Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: clojure
-lein: lein2
-script: lein2 cljsbuild test
+lein: lein
+script: lein cljsbuild test


### PR DESCRIPTION
This PR fixes the "lein2: command not found" error on Travis CI and makes builds pass again  by using `lein` instead of `lein2`. Travis now [uses Leiningen `2.4.x` by default](https://docs.travis-ci.com/user/languages/clojure/#ci-environment-for-clojure-projects).

Resolves https://github.com/lazerwalker/clojurescript-koans/issues/31.

/cc @lazerwalker 